### PR TITLE
Partially fix union types

### DIFF
--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -1,0 +1,16 @@
+const { selector, operation } = require('../../dist')
+
+// build a Selector object
+const Query = selector()
+// build an Operation builder
+const query = operation('query', Query)
+// build an example "query" operation
+const example = query("example", (t) => [
+  t.foo(),
+  t.bar(),
+  t.baz({ id: 'foo' }, (t) => [
+    t.id()
+  ]),
+]);
+
+console.log(example.toString())

--- a/examples/manual/index.ts
+++ b/examples/manual/index.ts
@@ -1,0 +1,24 @@
+import { selector, operation, Result } from "../../dist";
+
+interface Query {
+  foo: string;
+  bar: number;
+  baz: {
+    id: string;
+  };
+}
+
+// build a Selector object
+const Query = selector<Query>();
+// build an Operation builder
+const query = operation("query", Query);
+// build an example "query" operation
+const example = query("example", (t) => [
+  t.foo(),
+  t.bar(),
+  t.baz({ id: "foo" }, (t) => [t.id()]),
+]);
+
+type ExampleResult = Result<Query, typeof example["selectionSet"]>;
+
+console.log(example.toString());

--- a/examples/manual/index.ts
+++ b/examples/manual/index.ts
@@ -1,4 +1,4 @@
-import { selector, operation, Result } from "../../dist";
+import { selector, operation, Result } from "../../src";
 
 interface Query {
   foo: string;

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -4,32 +4,55 @@ import {
   Selection,
   SelectionSet,
   Operation,
-  Result,
+  Primitive,
 } from "./Operation";
 
-export interface IQuery {
-  /*foo: number, bar: string, */ [field: string]: any;
-}
-
-// generic query function
-export const query = <T extends Array<Selection>>(
+export const operation = <S extends ISelector<any>>(
+  type: "query" | "mutation" | "subscription",
+  selector: S
+) => <T extends Array<Selection>>(
   name: string,
-  select: (t: typeof Selector) => T
+  select: (t: S) => T
 ): Operation<SelectionSet<T>> =>
-  new Operation(name, "query", new SelectionSet(select(Selector)));
+  new Operation(name, type, new SelectionSet(select(selector)));
 
-// () => Field<string, never, any>
-// (variables: Record<string, any>) => Field<string, Argument<string, any>[], any>
-// (select: (selector: ISelector) => Array<Selection>) => Field<string, never, SelectionSet<T>>
-// (variables: Record<string, any>, select: (selector: ISelector) => Array<Selection>) => Field<string, Argument<string, any>[], SelectionSet<T>>
+export const selector = <T>(): ISelector<T> =>
+  new Proxy(Object.create(null), {
+    get(target, field) /*: FieldFn*/ {
+      return function fieldFn(...args: any[]) {
+        if (args.length === 0) {
+          return new Field<any, any, any>(field);
+        } else if (typeof args[0] === "function") {
+          return new Field<any, any, any>(
+            field,
+            undefined,
+            new SelectionSet(args[0](selector()))
+          );
+        } else if (typeof args[0] === "object") {
+          if (typeof args[1] === "function") {
+            return new Field<any, any, any>(
+              field,
+              Object.entries(args[0]).map(
+                ([name, value]) => new Argument(name, value)
+              ),
+              new SelectionSet(args[1](selector()))
+            );
+          } else {
+            return new Field<any, any, any>(
+              field,
+              Object.entries(args[0]).map(
+                ([name, value]) => new Argument(name, value)
+              )
+            );
+          }
+        }
 
-export const Selector: ISelector<any> = new Proxy(Object.create(null), {
-  get(target, field) {
-    return target.hasOwnProperty(field)
-      ? (target as any)[field]
-      : target._field(field as string); // @todo implement dynamic selector function
-  },
-});
+        throw new Error(`Unable to derive field function from arguments.`);
+      };
+    },
+  });
+
+// @todo replace these with types ex. `type Field0<F extends string> = () => Field<F>`
 
 export function field<F extends string>(): Field<F>;
 
@@ -50,43 +73,17 @@ export function field<
   select: (selector: ISelector<any>) => S
 ): Field<F, A, SelectionSet<S>>;
 
-export function field(): Field<any, any, any> {
+export function field(...args: any[]): Field<any, any, any> {
   // @todo implementation!
   return new Field<any, any, any>("todo");
 }
 
-type FieldFn = typeof field;
-
-// @note a generic selector interface
 export type ISelector<T> = {
-  // @todo Can we infer `F` from `field`?
-  [F in keyof T]: FieldFn;
+  // @todo use Paramaters<T> to support variables
+  [F in keyof T]: T[F] extends Primitive
+    ? (variables?: Record<string, any>) => Field<F extends string ? F : never>
+    : <S extends Array<Selection>>(
+        arg0: ((selector: ISelector<T[F]>) => S) | Record<string, any>,
+        arg1?: ((selector: ISelector<T[F]>) => S) | never
+      ) => Field<F extends string ? F : never, never, SelectionSet<S>>;
 };
-
-// export interface ISelector {
-//   // @todo Can we infer `F` from `field`?
-//   // [field: string]: <
-//   //   F extends string,
-//   //   A extends Array<Argument<any,any>> = never,
-//   // >() => Field<F, A, never>
-
-//   [field: string]: FieldFn
-// }
-
-const foo = query("example", (t) => [
-  t.foo(),
-  t.bar(),
-  // t.baz<'baz', Array<Selection>>(t => [
-  //   t.id<'id'>()
-  // ]),
-]);
-
-interface Tester {
-  foo: string;
-  bar: number;
-  baz: {
-    id: string;
-  };
-}
-
-type genericR = Result<Tester, typeof foo["selectionSet"]>;

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,0 +1,92 @@
+import {
+  Argument,
+  Field,
+  Selection,
+  SelectionSet,
+  Operation,
+  Result,
+} from "./Operation";
+
+export interface IQuery {
+  /*foo: number, bar: string, */ [field: string]: any;
+}
+
+// generic query function
+export const query = <T extends Array<Selection>>(
+  name: string,
+  select: (t: typeof Selector) => T
+): Operation<SelectionSet<T>> =>
+  new Operation(name, "query", new SelectionSet(select(Selector)));
+
+// () => Field<string, never, any>
+// (variables: Record<string, any>) => Field<string, Argument<string, any>[], any>
+// (select: (selector: ISelector) => Array<Selection>) => Field<string, never, SelectionSet<T>>
+// (variables: Record<string, any>, select: (selector: ISelector) => Array<Selection>) => Field<string, Argument<string, any>[], SelectionSet<T>>
+
+export const Selector: ISelector<any> = new Proxy(Object.create(null), {
+  get(target, field) {
+    return target.hasOwnProperty(field)
+      ? (target as any)[field]
+      : target._field(field as string); // @todo implement dynamic selector function
+  },
+});
+
+export function field<F extends string>(): Field<F>;
+
+export function field<F extends string, A extends Array<Argument<any, any>>>(
+  variables: Record<string, any>
+): Field<F, A>;
+
+export function field<F extends string, S extends Array<Selection>>(
+  select: (selector: ISelector<any>) => S
+): Field<F, never, SelectionSet<S>>;
+
+export function field<
+  F extends string,
+  A extends Array<Argument<any, any>> = never,
+  S extends Array<Selection> = never
+>(
+  variables: Record<string, any>,
+  select: (selector: ISelector<any>) => S
+): Field<F, A, SelectionSet<S>>;
+
+export function field(): Field<any, any, any> {
+  // @todo implementation!
+  return new Field<any, any, any>("todo");
+}
+
+type FieldFn = typeof field;
+
+// @note a generic selector interface
+export type ISelector<T> = {
+  // @todo Can we infer `F` from `field`?
+  [F in keyof T]: FieldFn;
+};
+
+// export interface ISelector {
+//   // @todo Can we infer `F` from `field`?
+//   // [field: string]: <
+//   //   F extends string,
+//   //   A extends Array<Argument<any,any>> = never,
+//   // >() => Field<F, A, never>
+
+//   [field: string]: FieldFn
+// }
+
+const foo = query("example", (t) => [
+  t.foo(),
+  t.bar(),
+  // t.baz<'baz', Array<Selection>>(t => [
+  //   t.id<'id'>()
+  // ]),
+]);
+
+interface Tester {
+  foo: string;
+  bar: number;
+  baz: {
+    id: string;
+  };
+}
+
+type genericR = Result<Tester, typeof foo["selectionSet"]>;

--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -29,11 +29,6 @@ import {
 
 type SetIntersection<A, B> = A extends B ? A : never;
 
-interface TQ {
-  [field: string]: number;
-}
-type Test = SetIntersection<keyof TQ, "ff">;
-
 export type Result<
   Type,
   TSelectionSet extends SelectionSet<Array<Selection>>
@@ -214,18 +209,6 @@ export function getBaseType(type: Type): NamedType<any, any> {
   }
 }
 
-/**
- * Utility type for parsing the base type from a `Type`
- *
- * Example:
- * type User = NamedType<'User', { id: string}>
- *
- * type A = BaseType<User>
- * type B = BaseType<ListType<User>>
- * type C = BaseType<NonNullType<User>>
- * type D = BaseType<NonNullType<ListType<User>>>
- * type E = BaseType<NonNullType<ListType<NonNullType<User>>>>
- */
 export type BaseType<T extends Type> = T extends NamedType<string, infer Type>
   ? Type
   : T extends NonNullType<infer Type>

--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -11,7 +11,6 @@ import {
   NamedTypeNode,
   InlineFragmentNode,
 } from "graphql";
-
 import {
   argumentOf,
   namedTypeOf,
@@ -54,7 +53,7 @@ export type Result<
     } &
       (TSelectionSet["selections"][number] extends infer U
         ? U extends InlineFragment<infer TypeCondition, infer SelectionSet>
-          ? TypeCondition extends NamedType<any, infer Type>
+          ? TypeCondition extends NamedType<string, infer Type>
             ? null extends Type
               ? Result<NonNullable<Type>, SelectionSet> | null
               : Result<Type, SelectionSet>

--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -27,6 +27,13 @@ import {
   documentOf,
 } from "./AST";
 
+type SetIntersection<A, B> = A extends B ? A : never;
+
+interface TQ {
+  [field: string]: number;
+}
+type Test = SetIntersection<keyof TQ, "ff">;
+
 export type Result<
   Type,
   TSelectionSet extends SelectionSet<Array<Selection>>
@@ -41,7 +48,7 @@ export type Result<
       [Key in FilterFragments<
         TSelectionSet["selections"]
       >[number]["name"]]: Type[Key] extends Primitive
-        ? Type[Key]
+        ? Type[Key] //SetIntersection<keyof Type, Key> extends never ?  unknown : Type[Key] // @note use `unknown` as the default type
         : TSelectionSet["selections"][number] extends infer U
         ? U extends Field<Key, any, infer Selections>
           ? null extends Type[Key]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./AST";
 export * from "./Operation";
 export * from "./Client";
+export * from "./Builder";
 export * from "./Codegen";


### PR DESCRIPTION
Fixes union type inference resulting from our codegen. Noting that it's only a "partial" fix as the following will still break it. 

Note: We can possibly solve this for the user by not exposing a `__typename` method on the `Selector` objects of union types and adding it implicitly to each `InlineFragment` generated by `on` selections.

```typescript
 (t) => [
    t.__typename(), //@note explodes types!

    t.on('InvalidTier', (t) => [t.__typename(), t.message()]),
    t.on('InvalidTierPrice', (t) => [t.__typename(), t.message()]),
    t.on('TierSubscription', (t) => [
      t.__typename(),
      t.id(),
      t.status(),
      t.tier((t) => [t.key()]),
    ]),
  ],
```

Works:

```typescript
 (t) => [
    t.on('InvalidTier', (t) => [t.__typename(), t.message()]),
    t.on('InvalidTierPrice', (t) => [t.__typename(), t.message()]),
    t.on('TierSubscription', (t) => [
      t.__typename(),
      t.id(),
      t.status(),
      t.tier((t) => [t.key()]),
    ]),
  ],
```

#31 