### PR TITLE
Partially fix union type inference

### DIFF
--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -11,7 +11,6 @@ import {
   NamedTypeNode,
   InlineFragmentNode,
 } from "graphql";
-
 import {
   argumentOf,
   namedTypeOf,
@@ -52,7 +51,7 @@ export type Result<
     } &
       (TSelectionSet["selections"][number] extends infer U
         ? U extends InlineFragment<infer TypeCondition, infer SelectionSet>
-          ? TypeCondition extends NamedType<any, infer Type>
+          ? TypeCondition extends NamedType<string, infer Type>
             ? null extends Type
               ? Result<NonNullable<Type>, SelectionSet> | null
               : Result<Type, SelectionSet>


### PR DESCRIPTION
Fixes union type inference resulting from our codegen. Noting that it's only a "partial" fix as the following will still break it. 

Note: We can possibly solve this for the user by not exposing a `__typename` method on the `Selector` objects of union types and adding it implicitly to each `InlineFragment` generated by `on` selections.

```typescript
 (t) => [
    t.__typename(), // @note explodes types!

    t.on('InvalidTier', (t) => [t.__typename(), t.message()]),
    t.on('InvalidTierPrice', (t) => [t.__typename(), t.message()]),
    t.on('TierSubscription', (t) => [
      t.__typename(),
      t.id(),
      t.status(),
      t.tier((t) => [t.key()]),
    ]),
  ],
```

Works:

```typescript
 (t) => [
    t.on('InvalidTier', (t) => [t.__typename(), t.message()]),
    t.on('InvalidTierPrice', (t) => [t.__typename(), t.message()]),
    t.on('TierSubscription', (t) => [
      t.__typename(),
      t.id(),
      t.status(),
      t.tier((t) => [t.key()]),
    ]),
  ],
```

#31 