### PR TITLE
Tweak Executor interface to work with TypeScript 4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.0.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.2.2"
   },
   "peerDependencies": {
     "graphql": "^15.3.0"

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -20,9 +20,9 @@ export class HTTPExecutor implements Executor {
 }
 
 export interface Executor {
-  execute<RootType, TOperation extends Operation<SelectionSet<any>>>(
-    operation: TOperation
-  ): Promise<ExecutionResult<Result<RootType, TOperation["selectionSet"]>>>;
+  execute<_A extends any, B extends Operation<SelectionSet<any>>>(
+    operation: B
+  ): unknown;
 }
 
 export const execute = <

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,10 +3749,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 uglify-js@^3.1.4:
   version "3.12.3"


### PR DESCRIPTION
Seems to fix the following error we started seeing with TypeScript 4.2+

```
“Type instantiation is excessively deep and possibly infinite” 
```