### PR TITLE
Field alias support

### DIFF
--- a/src/AST.ts
+++ b/src/AST.ts
@@ -119,25 +119,22 @@ export const selectionSet = <T extends ReadonlyArray<Selection>>(
 export interface Field<
   Name extends string,
   Arguments extends Array<Argument<string, any>> | undefined = undefined,
-  SS extends SelectionSet<any> | undefined = undefined
+  SS extends SelectionSet<any> | undefined = undefined,
+  AliasName extends string | undefined = undefined,
 > extends FieldNode {
   name: { kind: Kind.NAME; value: Name };
   arguments?: Arguments;
   selectionSet?: SS;
-  as<AliasName extends string>(alias: AliasName): AliasedField<AliasName, Name, Arguments, SS>
+  alias?: AliasNode<AliasName>;
+
+  as<AliasName extends string>(alias: AliasName): Field<Name, Arguments, SS, AliasName>
 }
 
-export interface AliasedField<
-  AliasName extends string,
-  Name extends string,
-  Arguments extends Array<Argument<string, any>> | undefined = undefined,
-  SS extends SelectionSet<any> | undefined = undefined
-> extends FieldNode {
-  name: { kind: Kind.NAME; value: Name };
-  alias: { kind: Kind.NAME; value: AliasName };
-  arguments?: Arguments;
-  selectionSet?: SS;
-}
+type AliasNode<AliasName extends string | undefined> =
+  AliasName extends string 
+    ? { kind: Kind.NAME, value: AliasName }
+    : undefined
+
 
 export const field = <
   Name extends string,
@@ -157,7 +154,7 @@ export const field = <
   as<AliasName extends string>(alias: AliasName) {
     return {
       ...this,
-      alias: { kind: Kind.NAME, value: alias }
+      alias: { kind: Kind.NAME, value: alias } as AliasNode<AliasName>
     }
   }
 });
@@ -216,8 +213,7 @@ export interface FragmentSpread<Name extends string>
 
 // SelectionNode
 export type Selection =
-  | Field<any, any, any>
-  | AliasedField<any, any, any, any>
+  | Field<any, any, any, any>
   | InlineFragment<any, any>
   | FragmentSpread<any>;
 

--- a/src/AST.ts
+++ b/src/AST.ts
@@ -124,6 +124,19 @@ export interface Field<
   name: { kind: Kind.NAME; value: Name };
   arguments?: Arguments;
   selectionSet?: SS;
+  as<AliasName extends string>(alias: AliasName): AliasedField<AliasName, Name, Arguments, SS>
+}
+
+export interface AliasedField<
+  AliasName extends string,
+  Name extends string,
+  Arguments extends Array<Argument<string, any>> | undefined = undefined,
+  SS extends SelectionSet<any> | undefined = undefined
+> extends FieldNode {
+  name: { kind: Kind.NAME; value: Name };
+  alias: { kind: Kind.NAME; value: AliasName };
+  arguments?: Arguments;
+  selectionSet?: SS;
 }
 
 export const field = <
@@ -141,6 +154,12 @@ export const field = <
   arguments: args,
   alias: undefined,
   selectionSet: selectionSet,
+  as<AliasName extends string>(alias: AliasName) {
+    return {
+      ...this,
+      alias: { kind: Kind.NAME, value: alias }
+    }
+  }
 });
 
 export interface InlineFragment<
@@ -198,6 +217,7 @@ export interface FragmentSpread<Name extends string>
 // SelectionNode
 export type Selection =
   | Field<any, any, any>
+  | AliasedField<any, any, any, any>
   | InlineFragment<any, any>
   | FragmentSpread<any>;
 

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -1,7 +1,7 @@
 import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { L, Test } from "ts-toolbelt";
 
-import type { AliasedField, Field, InlineFragment, NamedType, Selection, SelectionSet } from "./AST";
+import type { Field, InlineFragment, NamedType, Selection, SelectionSet } from "./AST";
 
 // @note `Result` takes a root `Type` (TS) and `SelectionSet` (GQL) and recursively walks the
 // array of `Selection` nodes's (i.e `Field`, `InlineFragment`, or `FragmentSpread` nodes)
@@ -33,8 +33,10 @@ export type Result<
     Parent;
 
 type InferName<F> =
-  F extends Field<infer Name, any, any> | AliasedField<infer Name, any, any, any>
-    ? Name
+  F extends Field<infer Name, any, any, infer AliasName>
+    ? AliasName extends string 
+      ? AliasName
+      : Name
     : never;
 
 type InferResult<
@@ -42,7 +44,7 @@ type InferResult<
   Schema extends Record<string, any>,
   Parent extends Record<string, any>
 > =
-  F extends Field<infer Name, any, infer SS> | AliasedField<any, infer Name, any, infer SS>
+  F extends Field<infer Name, any, infer SS, any>
     ? Result<Schema, InferParent<Parent, Name>, SS>
     : never
 
@@ -67,7 +69,7 @@ export type SpreadFragments<
 export type SpreadFragment<
   Schema extends Record<string, any>,
   Fragment extends InlineFragment<any, any>,
-  CommonSelection extends SelectionSet<ReadonlyArray<Field<any, any, any> | AliasedField<any, any, any>>>,
+  CommonSelection extends SelectionSet<ReadonlyArray<Field<any, any, any, any>>>,
 > = Fragment extends InlineFragment<
   NamedType<infer Typename>,
   infer SelectionSet

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -1,8 +1,7 @@
-import { ResultOf, TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { L, Test } from "ts-toolbelt";
 
-import type { Field, InlineFragment, NamedType, Selection, SelectionSet } from "./AST";
-import type { Selection as SchemaSelection } from "./Selection"
+import type { AliasedField, Field, InlineFragment, NamedType, Selection, SelectionSet } from "./AST";
 
 // @note `Result` takes a root `Type` (TS) and `SelectionSet` (GQL) and recursively walks the
 // array of `Selection` nodes's (i.e `Field`, `InlineFragment`, or `FragmentSpread` nodes)
@@ -16,33 +15,42 @@ export type Result<
   Selected extends SelectionSet<ReadonlyArray<Selection>> | undefined,
 > =
   // Lists
-  Parent extends Array<infer T> | ReadonlyArray<infer T> ? ReadonlyArray<Result<Schema, T, Selected>>
+  Parent extends Array<infer T> | ReadonlyArray<infer T>
+    ? ReadonlyArray<Result<Schema, T, Selected>>
     : // Objects
     Parent extends Record<string, any>
       ? Selected extends SelectionSet<ReadonlyArray<Selection>>
-        ? HasInlineFragment<Selected> extends Test.Pass ? SpreadFragments<Schema, Selected>
-        : {
-          readonly // @todo cleanup mapped typed field name mapping
-          [
-            F in Selected["selections"][number] as F extends Field<
-              infer Name,
-              any,
-              any
-            > ? Name
-              : never
-          ]: F extends Field<infer Name, any, infer SS> ? Result<
-            Schema,
-            /* @note support parameterized fields */ Parent[Name] extends (
-              variables: any,
-            ) => infer T ? T
-              : Parent[Name], /*Parent[Name]*/
-            SS
-          >
-            : never;
-        }
-      : never
+        ? HasInlineFragment<Selected> extends Test.Pass
+          ? SpreadFragments<Schema, Selected>
+          : {
+            // @todo cleanup mapped typed field name mapping
+            readonly [
+              F in Selected["selections"][number] as InferName<F>
+            ]: InferResult<F, Schema, Parent>;
+          }
+        : never
     : // Scalars
     Parent;
+
+type InferName<F> =
+  F extends Field<infer Name, any, any> | AliasedField<infer Name, any, any, any>
+    ? Name
+    : never;
+
+type InferResult<
+  F,
+  Schema extends Record<string, any>,
+  Parent extends Record<string, any>
+> =
+  F extends Field<infer Name, any, infer SS> | AliasedField<any, infer Name, any, infer SS>
+    ? Result<Schema, InferParent<Parent, Name>, SS>
+    : never
+
+/* @note support parameterized fields */
+type InferParent<Parent extends Record<string, any>, Name extends string> =
+  Parent[Name] extends (variables: any) => infer T
+    ? T
+    : Parent[Name]
 
 export type SpreadFragments<
   Schema extends Record<string, any>,
@@ -59,7 +67,7 @@ export type SpreadFragments<
 export type SpreadFragment<
   Schema extends Record<string, any>,
   Fragment extends InlineFragment<any, any>,
-  CommonSelection extends SelectionSet<ReadonlyArray<Field<any, any, any>>>,
+  CommonSelection extends SelectionSet<ReadonlyArray<Field<any, any, any> | AliasedField<any, any, any>>>,
 > = Fragment extends InlineFragment<
   NamedType<infer Typename>,
   infer SelectionSet

--- a/src/Variables.ts
+++ b/src/Variables.ts
@@ -63,7 +63,7 @@ export type Variables<
     ? {}
     : S extends SelectionSet<ReadonlyArray<Selection>>
     ? S["selections"][number] extends infer Selection
-      ? Selection extends Field<infer FieldName, infer FieldArgs, infer SS>
+      ? Selection extends Field<infer FieldName, infer FieldArgs, infer SS, any>
         ? O.Merge<
             FilterMapArguments<RootType, FieldName, FieldArgs>,
             Variables<Schema, RootType[FieldName], SS>

--- a/test-d/field-alias.test-d.ts
+++ b/test-d/field-alias.test-d.ts
@@ -1,0 +1,49 @@
+import { expectAssignable } from "tsd";
+import freeze from "deep-freeze";
+import { selectionSet, Result, field } from "../src";
+
+interface Schema {
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  ID: string;
+
+  Query: Query;
+  User: User;
+}
+
+interface Query {
+  __typename: "Query";
+  userById: User | null;
+}
+
+interface User {
+  __typename: "User";
+  id: string;
+  firstName: string;
+  age: number | null;
+}
+
+const selection = selectionSet([
+  field("userById", undefined, selectionSet([
+    field("firstName").as("name")
+  ]))
+])
+
+type Test = Result<Schema, Query, typeof selection>;
+
+expectAssignable<Test>(
+  freeze({
+    userById: {
+      name: "test"
+    }
+  })
+)
+
+expectAssignable<Test>(
+  freeze({
+    userById: null
+  })
+)
+


### PR DESCRIPTION
This extends the API to support field aliasing, which is quite necessary when same field has to be fetched multiple times with different args/selections. 

Usage:

```ts
const selection = query(t => [
    t.images({ count: 10 }, t => [
        t.title(),
        t.url()
    ]).as("recentPhotos"),
    t.images({ count: 10, author: "lorefnon" }, t => [
        t.title(),
        t.url()
    ]).as("ownPhotos")
]).toQuery({ queryName: "fetchPhotos" })
```

```graphql
query fetchPhotos {
    recentPhotos: images(count: 10) {
        title
        url
    }
    ownPhotos: images(count: 10, author: "lorefnon") {
        title
        url
    }
}
```