### PR TITLE
Export the selector interfaces

### DIFF
--- a/codegen/src/transforms/selectors.ts
+++ b/codegen/src/transforms/selectors.ts
@@ -202,7 +202,7 @@ export const transform = (
 
       return code`
         ${/* selector interface */ ""}
-        interface I${type.name}Selector {
+        export interface I${type.name}Selector {
           readonly __typename: () => Field<"__typename">
           ${fields.map(printSignature).join("\n")}
         }


### PR DESCRIPTION
So, we have the support for defining reusable selectors, but I find that to be not so great wrt type-safety. 

Let's say I have following schema: 

```graphql
type Mutation {
  setupInstance(input: InstanceSetupInput!): SetupInstanceResult!
}

type SetupInstanceResult {
  config: InstanceConfig!
}

type InstanceConfig {
  isSetup: Boolean!
}
```

Now I define a selector for InstanceConfig type: 

```ts
  const instanceConfigFields = instanceConfig(t => [
    t.isSetup(),
  ])
```

Ideally my mutation invocation should be like  this: 

```ts
mutation(t => [
      t.setupInstance({ input }, t => [
        t.config(t => [
          ...instanceConfigFields
        ])
      ])
]).toQuery({})
```

However if I make a mistake and spread it one level up: 

```ts
mutation(t => [
      t.setupInstance({ input }, t => [
          ...instanceConfigFields
      ])
]).toQuery({})
```

This does not result in a type error, because the default type params of setupInstance accept any selection: 

```ts
  readonly setupInstance: <
    V extends { input: Variable<string> | IInstanceSetupInput },
    T extends ReadonlyArray<Selection>
  > ... 
```

I can explicitly pass the type parameter for T but that is not so ergonomic. 

So what I'd like to do instead is to make the selector interface exposed from generated sdk and define reusable selector functions: 

```ts
import { IInstanceConfigSelector } from "./sdk" 

export const selectInstanceConfig = (t: IInstanceConfigSelector) => [
    t.isSetup()
]

// Later in mutation: 

mutation(t => [
      t.setupInstance({ input }, t => [
        t.config(t => [
          ...selectInstanceConfig(t)
        ])
      ])
]).toQuery({})
```

This makes the usage type-safe.