### PR TITLE
Make Selection#toString returns string representation of complete operation

### DIFF
--- a/src/Selection.ts
+++ b/src/Selection.ts
@@ -20,6 +20,12 @@ import { Variables, buildVariableDefinitions } from "./Variables";
 
 type Element<T> = T extends Array<infer U> ? U : never;
 
+interface OperationOpts {
+  queryName?: string;
+  useVariables?: boolean;
+  dropNullInputValues?: boolean;
+}
+
 export class Selection<
   Schema extends Record<string, any>,
   RootType extends string /* @todo keyof Schema*/,
@@ -59,11 +65,7 @@ export class Selection<
   }
 
   // toOperation? toDocument?
-  toQuery(options: {
-    queryName?: string;
-    useVariables?: boolean;
-    dropNullInputValues?: boolean;
-  }): TypedDocumentNode<
+  toQuery(options?: OperationOpts): TypedDocumentNode<
     Result<Schema, Schema[RootType], AST.SelectionSet<T>>,
     Variables<Schema, Schema[RootType], AST.SelectionSet<T>>
   > {
@@ -86,7 +88,7 @@ export class Selection<
 
     const operationDefinition = operation(
       op,
-      options.queryName ?? "Anonymous",
+      options?.queryName ?? "Anonymous",
       selectionSet,
       variableDefinitions
     );
@@ -99,8 +101,8 @@ export class Selection<
 
   // @todo toRequest (converts to node-fetch API compatible `Request` object)
 
-  toString() {
-    return print(this.toSelectionSet());
+  toString(options?: OperationOpts) {
+    return print(this.toQuery(options));
   }
 }
 

--- a/src/__tests__/Selection.test.ts
+++ b/src/__tests__/Selection.test.ts
@@ -1,9 +1,67 @@
 import { Selection } from "../Selection";
+import { buildSchema } from "graphql";
+import { argument, field, selectionSet } from "../AST";
 
 describe("Selection", () => {
   it.todo("is an Array of Selection AST objects");
   it.todo("converts to a SelectionSet AST object");
   it.todo("converts to an InlineFragment AST object");
   it.todo("converts to a NamedFragment AST object");
-  it.todo("converts to a string");
+
+  it("converts to a string", () => {
+    const schema = buildSchema(
+      `
+      type Query {
+        currentUser: User!
+      }
+
+      type Mutation {
+        createUser(user: UserInput!): User!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        friends(limit: Int!): [User!]
+      }
+
+      input UserInput {
+        name: String!
+      }
+    `,
+      { noLocation: true }
+    );
+
+    const selection = new Selection(schema, "Mutation", [
+      field(
+        "createUser",
+        [
+          argument("user", {
+            name: "John Doe",
+          }),
+        ],
+        selectionSet([field("id")])
+      ),
+    ]);
+
+    expect(
+      selection.toString({
+        queryName: "createUser",
+      })
+    ).toMatchInlineSnapshot(`
+      "mutation createUser {
+        createUser(user: {name: \\"John Doe\\"}) {
+          id
+        }
+      }"
+    `);
+
+    expect(selection.toString()).toMatchInlineSnapshot(`
+      "mutation Anonymous {
+        createUser(user: {name: \\"John Doe\\"}) {
+          id
+        }
+      }"
+    `);
+  });
 });


### PR DESCRIPTION
`Selection#toString` currently returns the string representation of selectionSet which is weird for anything other than query. 

I was using it with [graphql-ws](https://github.com/enisdenjo/graphql-ws), passing the outcome of toString() to subscribe, which worked for queries, but started failing for mutations because in absense of operation type server defaults to Query type.

I propose that `toString` basically be the string analogue of `toQuery`.

This is a breaking change in behavior, but I don't think many people would be using toString for mutations/subscriptions etc. as the current output would need some postprocessing before it can be used.